### PR TITLE
moved logic to LoginForm. created PrivateRoute.

### DIFF
--- a/web/src/components/AppContext.js
+++ b/web/src/components/AppContext.js
@@ -1,4 +1,4 @@
 import React, { createContext } from 'react';
 
-
+export const IsAuthContext = createContext('false');
 export const IsAdminContext = createContext('false');

--- a/web/src/components/DisplayComponent.js
+++ b/web/src/components/DisplayComponent.js
@@ -14,6 +14,8 @@ import { renameStaticTableFields } from './fieldNameAliases';
 
 
 class DisplayComponent extends Component {
+  _isMounted = false;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -60,6 +62,7 @@ class DisplayComponent extends Component {
   }
 
   componentDidMount() {
+    this._isMounted = true;
     const { initFetch, initDataKeyToParse, initPageSize, initPageNum } = this.props;
 
     let getAllData = Promise.all([
@@ -68,17 +71,18 @@ class DisplayComponent extends Component {
     ]);
 
     getAllData.then(([data, markupData]) => {
-
-      this.setState({
-        items: data[initDataKeyToParse],
-        isLoaded: true,
-        totalItemsCount: data.count,
-        totalPages: data.total_pages,
-        nextPage: data.next,
-        previousPage: data.previous,
-        globalMarkup: markupData
-      });
-    })
+      if (this._isMounted) {
+        this.setState({
+          items: data[initDataKeyToParse],
+          isLoaded: true,
+          totalItemsCount: data.count,
+          totalPages: data.total_pages,
+          nextPage: data.next,
+          previousPage: data.previous,
+          globalMarkup: markupData
+        });        
+      }
+    });
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -105,6 +109,10 @@ class DisplayComponent extends Component {
         });
       })
     }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   filterOutputData() {

--- a/web/src/components/HomeComponent.js
+++ b/web/src/components/HomeComponent.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const HomeComponent = () => {
+  return (
+    <p>Home. Add Links here later</p>
+  );
+};
+
+export default HomeComponent;

--- a/web/src/components/MainRoutes.js
+++ b/web/src/components/MainRoutes.js
@@ -32,6 +32,8 @@ import {
   JobEdit
 } from './Jobs';
 import { LoginForm, SignupForm } from './Auth';
+import { PrivateRoute } from './helpers';
+import HomeComponent from './HomeComponent';
 // import SearchByRoute from './SearchByRoute';
 import NotFound from './NotFound';
 import {
@@ -63,31 +65,31 @@ const MainRoutes = () => {
   return (
     <main>
       <Switch>
-        <Route path={HOME_PATH} />
+        <PrivateRoute path={HOME_PATH} component={HomeComponent} />
         <Route exact path={LOGIN_PATH} component={LoginForm} />
-        <Route exact path={SIGNUP_PATH} component={SignupForm} />
+        <PrivateRoute exact path={SIGNUP_PATH} component={SignupForm} />
 
-        <Route path={PARTS_DISPLAY_ADMIN_PATH} component={PartsAdminDisplay} />
-        <Route exact path={PARTS_DISPLAY_PATH} component={PartsDisplay} />
-        <Route exact path={PART_DETAIL_PATH} component={PartDetailWithState} />
-        <Route path={PART_EDIT_PATH} component={EditPartsForm} />
+        <PrivateRoute path={PARTS_DISPLAY_ADMIN_PATH} component={PartsAdminDisplay} />
+        <PrivateRoute exact path={PARTS_DISPLAY_PATH} component={PartsDisplay} />
+        <PrivateRoute exact path={PART_DETAIL_PATH} component={PartDetailWithState} />
+        <PrivateRoute path={PART_EDIT_PATH} component={EditPartsForm} />
 
-        <Route exact path={TASKS_DISPLAY_PATH} component={TasksDisplay} />
-        <Route exact path={TASK_DETAIL_PATH} component={TaskDetail} />
-        <Route exact path={TASK_EDIT_PATH} component={TaskEdit} />
+        <PrivateRoute exact path={TASKS_DISPLAY_PATH} component={TasksDisplay} />
+        <PrivateRoute exact path={TASK_DETAIL_PATH} component={TaskDetail} />
+        <PrivateRoute exact path={TASK_EDIT_PATH} component={TaskEdit} />
 
-        <Route exact path={CATEGORIES_DISPLAY_PATH} component={CategoriesDisplay} />
-        <Route exact path={CATEGORY_DETAIL_PATH} component={CategoryDetail} />
-        <Route exact path={CATEGORY_EDIT_PATH} component={CategoryEdit} />
+        <PrivateRoute exact path={CATEGORIES_DISPLAY_PATH} component={CategoriesDisplay} />
+        <PrivateRoute exact path={CATEGORY_DETAIL_PATH} component={CategoryDetail} />
+        <PrivateRoute exact path={CATEGORY_EDIT_PATH} component={CategoryEdit} />
 
-        <Route exact path={JOBS_DISPLAY_PATH} component={JobsDisplay} />
-        <Route exact path={JOB_DETAIL_PATH} component={JobDetail} />
-        <Route exact path={JOB_EDIT_PATH} component={JobEdit} />
+        <PrivateRoute exact path={JOBS_DISPLAY_PATH} component={JobsDisplay} />
+        <PrivateRoute exact path={JOB_DETAIL_PATH} component={JobDetail} />
+        <PrivateRoute exact path={JOB_EDIT_PATH} component={JobEdit} />
         
-        <Route exact path={CREATE_PARTS_PATH} component={CreatePartsForm} />
-        <Route exact path={CREATE_TASKS_PATH} component={CreateTasksForm} />
-        <Route exact path={CREATE_CATEGORIES_PATH} component={CreateCategoriesForm} />
-        <Route exact path={CREATE_JOBS_PATH} component={CreateJobsForm} />
+        <PrivateRoute exact path={CREATE_PARTS_PATH} component={CreatePartsForm} />
+        <PrivateRoute exact path={CREATE_TASKS_PATH} component={CreateTasksForm} />
+        <PrivateRoute exact path={CREATE_CATEGORIES_PATH} component={CreateCategoriesForm} />
+        <PrivateRoute exact path={CREATE_JOBS_PATH} component={CreateJobsForm} />
         <Route component={NotFound} />
       </Switch>
     </main>

--- a/web/src/components/NavBar.js
+++ b/web/src/components/NavBar.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Route, Link } from 'react-router-dom';
 
+import { IsAdminContext } from './AppContext';
 import {
   HOME_PATH,
   BASE_PATH,
@@ -24,7 +25,8 @@ const ulStyle = {
   justifyContent: 'space-evenly'
 }
 
-const NavBar = ({ handleLogout, userIsAdmin }) => {
+const NavBar = ({ handleLogout }) => {
+  const userIsAdmin = useContext(IsAdminContext);
   const registerLink = userIsAdmin ?
     <li><Link to={SIGNUP_PATH}>Register New User</Link></li>
     : '';

--- a/web/src/components/helpers/PrivateRoute.js
+++ b/web/src/components/helpers/PrivateRoute.js
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { LOGIN_PATH } from '../frontendBaseRoutes';
+import { IsAuthContext } from '../AppContext'; 
+import { LoginForm } from '../Auth';
+
+const PrivateRoute = ({ component: Component, ...rest }) => {
+  const authContext = useContext(IsAuthContext);
+
+  return (
+    <Route { ...rest } render={(props) => {
+      return (
+        authContext ? <Component {...props} /> : <Redirect to={LOGIN_PATH} />
+      )}}
+    />
+  );
+};
+
+export default PrivateRoute;

--- a/web/src/components/helpers/index.js
+++ b/web/src/components/helpers/index.js
@@ -1,0 +1,1 @@
+export {default as PrivateRoute } from './PrivateRoute';


### PR DESCRIPTION
- DisplayComponent needed _isMounted checks to cancel async calls. For ex, if user started at /web/parts and not logged in, logs in, react-router will redirect to HOME_PATH. But because user started at /web/parts, the DisplayComponent mounts and api calls triggered (from componentDidMount). Redirect happens then async calls and finishes and setState triggers a warning that the component (DisplayComponent) no longer exists to setState on.