### PR TITLE
direct webpack bundles to /web/dist.

### DIFF
--- a/pmd/settings.py
+++ b/pmd/settings.py
@@ -180,20 +180,34 @@ if USE_WEBPACK_PROD:
   WEBPACK_LOADER = {
     'DEFAULT': {
       'BUNDLE_DIR_NAME': 'web/prod/bundles/',
-      'STATS_FILE': os.path.join(BASE_DIR + '/web/', 'webpack-stats.prod.json'),
+      'STATS_FILE': os.path.join(BASE_DIR + '/web/dist/', 'webpack-stats.prod.json'),
     }
   }
-else:  
-  WEBPACK_LOADER = {
-    'DEFAULT': {
-      'CACHE': not DEBUG,
-      'BUNDLE_DIR_NAME': 'web/bundles/',
-      'STATS_FILE': os.path.join(BASE_DIR + '/web/', 'webpack-stats.dev.json'),
-      'POLL_INTERVAL': 0.1,
-      'TIMEOUT': None,
-      'IGNORE': ['.+\.hot-update.js', '.+\.map']
+else:
+  # toggle this in local_settings
+  WEBPACK_PROD_TEST = init_settings.WEBPACK_PROD_TEST == 'TRUE'
+  if WEBPACK_PROD_TEST:
+    WEBPACK_LOADER = {
+      'DEFAULT': {
+        'CACHE': not DEBUG,
+        'BUNDLE_DIR_NAME': 'web/dist/bundles/',
+        'STATS_FILE': os.path.join(BASE_DIR + '/web/dist/', 'webpack-stats.prod.json'),
+        'POLL_INTERVAL': 0.1,
+        'TIMEOUT': None,
+        'IGNORE': ['.+\.hot-update.js', '.+\.map']
+      }
     }
-  }
+  else:
+    WEBPACK_LOADER = {
+      'DEFAULT': {
+        'CACHE': not DEBUG,
+        'BUNDLE_DIR_NAME': 'web/bundles/',
+        'STATS_FILE': os.path.join(BASE_DIR + '/web/', 'webpack-stats.dev.json'),
+        'POLL_INTERVAL': 0.1,
+        'TIMEOUT': None,
+        'IGNORE': ['.+\.hot-update.js', '.+\.map']
+      }
+    }
 
 
 # rest_framework configs

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "webpack --watch --mode development ./src/index.js --output ./static/web/main.js",
     "dev-wp": "webpack-dev-server --config webpack.config.js --mode development",
-    "build-prod": "webpack --mode production --config webpack.prod.js"
+    "build-prod": "webpack --mode production --config webpack.prod.js",
+    "test-build-prod": "webpack-dev-server --config webpack.prod.test.js --mode development"
   },
   "keywords": [],
   "author": "",

--- a/web/webpack.prod.js
+++ b/web/webpack.prod.js
@@ -14,12 +14,12 @@ module.exports = {
     new CleanWebpackPlugin(),
     new BundleTracker({
       filename: 'webpack-stats.prod.json',
-      path: path.resolve(__dirname, './static/web/prod/')
+      path: path.resolve('./dist/')
     }),
   ],
   output: {
     filename: '[name]-[hash].prod.bundle.js',
-    path: path.resolve(__dirname, './static/web/prod/bundles/')
+    path: path.resolve('./dist/bundles/')
   },
   module: {
     rules: [

--- a/web/webpack.prod.test.js
+++ b/web/webpack.prod.test.js
@@ -1,0 +1,52 @@
+
+var path = require('path');
+var webpack = require('webpack');
+var BundleTracker = require('webpack-bundle-tracker');
+
+
+module.exports = {
+  context: __dirname,
+  mode: 'development',
+  entry: [
+    'webpack-dev-server/client?http://localhost:3000',
+    'webpack/hot/dev-server',
+    './src/index',
+  ],
+  devtool: 'inline-source-map',
+  output: {
+    path: path.resolve('./dist/bundles/'),
+    filename: '[name]-[hash].js',
+    publicPath: 'http://localhost:3000/static/web/bundles/',
+  },
+  devServer: {
+    contentBase: './dist/bundles/',
+    historyApiFallback: true,
+    hot: true,
+    port: 3000,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader"
+        }
+      },
+
+    ]
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new BundleTracker({
+      filename: 'webpack-stats.prod.json',
+      path: path.resolve('./dist/')
+    }),
+  ],
+  resolve: {
+    extensions: ['*', '.js', '.jsx']
+  }
+};


### PR DESCRIPTION
- added "test-build-prod" to package.json. Purpose is to create the Stats and bundles into the correct path. 
- test-build-prod will run the bundles from the /web/dist/ path. local_settings.py needs WEBPACK_PROD_TEST = 'TRUE' for this test.