### PR TITLE
jobs query refactored. Html table build with <table> and <div> to test performance.

### DIFF
--- a/pdf_tasks/templates/jobs_cats_div_table_pdf.html
+++ b/pdf_tasks/templates/jobs_cats_div_table_pdf.html
@@ -1,0 +1,79 @@
+<html>
+  <head>
+    <p>Jobs to Cats to PDF</p>
+    <style>
+      .resp-table {
+        display: table;
+      }
+      .resp-table-row {
+        display: table-row;
+      }
+      .resp-table-cell {
+        display: table-cell;
+      }
+    </style>
+  </head>
+
+  <body>
+    {% for jd, job_data in jobs_data.items %}
+      <h2>{{ job_data.job_name }}</h2>
+      {% for j, categories in job_data.items %}
+        {% for cat, category in categories.items %}
+          <p><h3>{{ category.category_name }}</h3></p>
+          <p><h4>Task - Total tasks in this category: {{category.task|length}}</h4></p>
+          <div class="resp-table">
+            <div class="resp-table-row">
+              <div class="resp-table-cell">ID</div>
+              <div class="rresp-table-cell">Task ID</div>
+              <div class="resp-table-cell">Task Name</div>
+              <div class="resp-table-cell">Attribute</div>
+              <div class="resp-table-cell">Val Rate</div>
+              <div class="resp-table-celll">Std Rate</div>
+            </div>
+
+
+            {% for t, tasks in category.task.items %}
+  
+            <div class="resp-table-row">
+              <div class="resp-table-cell">{{ tasks.id }}</div>
+              <div class="resp-table-cell">{{ tasks.task_id }}</div>
+              <div class="resp-table-cell">{{ tasks.task_name }}</div>
+              <div class="resp-table-cell">{{ tasks.attribute }}</div>
+              <div class="resp-table-cell">{{ tasks.task_value_rate}}</div>
+              <div class="resp-table-cell">{{ tasks.task_std_rate}}</div>
+            </div>
+            {% endfor %}
+          </div>
+            
+  
+          <p><h4>Addon - Total addons in this category: {{category.addon|length}}</h4></p>
+          <div class="resp-table">
+            <div class="resp-table-row">
+              <div class="resp-table-cell">ID</div>
+              <div class="rresp-table-cell">Task ID</div>
+              <div class="resp-table-cell">Task Name</div>
+              <div class="resp-table-cell">Attribute</div>
+              <div class="resp-table-cell">Val Rate</div>
+              <div class="resp-table-celll">Std Rate</div>
+            </div>
+
+             
+            {% for a, addons in category.addon.items %}
+            <div class="resp-table-row">
+              <div class="resp-table-cell">{{ addons.id }}</div>
+              <div class="resp-table-cell">{{ addons.task_id }}</div>
+              <div class="resp-table-cell">{{ addons.task_name }}</div>
+              <div class="resp-table-cell">{{ addons.attribute }}</div>
+              <div class="resp-table-cell">{{ addons.addon_value_rate}}</div>
+              <div class="resp-table-cell">{{ addons.addon_std_rate}}</div>
+            </div>
+            {% endfor %}
+          </div>
+
+         <div class="pagebreak" style="page-break-before:always;"> </div>    
+        {% endfor %}
+      {% endfor %}
+    {% endfor %}
+
+  </body>
+</html>

--- a/pdf_tasks/templates/jobs_cats_html_table_pdf.html
+++ b/pdf_tasks/templates/jobs_cats_html_table_pdf.html
@@ -1,0 +1,73 @@
+<html>
+  <head>
+    <p>Jobs to Cats to PDF</p>
+    <style>
+      td {
+        text-align: center;
+      }
+    </style>
+  </head>
+
+  <body>
+    {% for jd, job_data in jobs_data.items %}
+      <h2>{{ job_data.job_name }}</h2>
+      {% for j, categories in job_data.items %}
+        {% for cat, category in categories.items %}
+          <p><h3>{{ category.category_name }}</h3></p>
+          <p><h4>Task - Total tasks in this category: {{category.task|length}}</h4></p>
+          <table>
+            <thead>
+              <th>ID</th>
+              <th>Task ID</th>
+              <th>Task Name</th>
+              <th>Attribute</th>
+              <th>Standard Rate</th>
+              <th>Value Rate</th>
+            </thead>
+            
+            <tbody>
+              {% for t, tasks in category.task.items %}
+              <tr>
+                <td>{{ tasks.id }}</td>
+                <td>{{ tasks.task_id }}</td>
+                <td>{{ tasks.task_name }}</td>
+                <td>{{ tasks.attribute }}</td>
+                <td>{{ tasks.task_value_rate}}</td>
+                <td>{{ tasks.task_std_rate}}</td>
+              </tr>
+              {% endfor %}
+
+            </tbody>
+          </table>
+
+
+          <p><h4>Addon - Total addons in this category: {{category.addon|length}}</h4></p>
+          <table>
+            <thead>
+              <th>ID</th>
+              <th>Task ID</th>
+              <th>Task Name</th>
+              <th>Attribute</th>
+              <th>Standard Rate</th>
+              <th>Value Rate</th>
+            </thead>
+
+            <tbody>
+              {% for a, addons in category.addon.items %}
+              <tr>
+                <td>{{ addons.task_id }}</td>
+                <td>{{ addons.task_name }}</td>
+                <td>{{ addons.attribute }}</td>
+                <td>{{ addons.addon_value_rate}}</td>
+                <td>{{ addons.addon_std_rate}}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+         <div class="pagebreak" style="page-break-before:always;"> </div>    
+        {% endfor %}
+      {% endfor %}
+    {% endfor %}
+
+  </body>
+</html>

--- a/pdf_tasks/urls.py
+++ b/pdf_tasks/urls.py
@@ -14,4 +14,11 @@ urlpatterns = [
   path('book_render_all/', views.render_all),
 
   path('cat_as_pdf/', views.render_categories_as_pdf),
+  # new query with html table
+  path('html_table/', views.jobs_with_related_categories_as_html),
+  path('html_table_as_pdf/', views.jobs_with_related_categories_as_pdf),
+
+  # table with css
+  path('div_table/', views.jobs_div_table_as_html),
+  path('div_table_as_pdf/', views.jobs_div_table_as_pdf),
 ]

--- a/web/src/components/NavBar.js
+++ b/web/src/components/NavBar.js
@@ -34,13 +34,27 @@ const NavBar = ({ handleLogout }) => {
   const newPdfPath = 'assets/cat_as_pdf/';
   const fullCatAsPdfPath = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + newPdfPath : PROD_BASE_PATH + newPdfPath;
   // remove after testinng
-  const pdfApi100Path = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_api_100/' : PROD_BASE_PATH + 'assets/book_api_100/';
-  const pdfApi400Path = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_api_400/' : PROD_BASE_PATH + 'assets/book__api_400/';
-  const pdfApiAllPath = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_api_all/' : PROD_BASE_PATH + 'assets/book_api_all/';
+  // const pdfApi100Path = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_api_100/' : PROD_BASE_PATH + 'assets/book_api_100/';
+  // const pdfApi400Path = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_api_400/' : PROD_BASE_PATH + 'assets/book__api_400/';
+  // const pdfApiAllPath = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_api_all/' : PROD_BASE_PATH + 'assets/book_api_all/';
 
   const pdfRender100Path = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_render_100/' : PROD_BASE_PATH + 'assets/book_render_100/';
   const pdfRender400Path = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_render_400/' : PROD_BASE_PATH + 'assets/book_render_400/';
   const pdfRenderAllPath = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + 'assets/book_render_all/' : PROD_BASE_PATH + 'assets/book_render_all/';
+
+
+  // jobs query testing with <table> and <div> tables
+  const htmlTableHtml = 'assets/html_table/';
+  const htmlTablePdf = 'assets/html_table_as_pdf/'
+  const navHtmlTable = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + htmlTableHtml : PROD_BASE_PATH + htmlTableHtml;
+  const navPdfTable = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + htmlTablePdf : PROD_BASE_PATH + htmlTablePdf;
+
+
+  const divTablePath = 'assets/div_table/';
+  const divTablePdf = 'assets/div_table_as_pdf/';
+  const navDivTable = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + divTablePath : PROD_BASE_PATH + divTablePath;
+  const navPdfDiv = (process.env.LOCAL_PATH) ? process.env.LOCAL_PATH + divTablePdf : PROD_BASE_PATH + divTablePdf;
+
 
   return (
     <div>
@@ -75,17 +89,19 @@ const NavBar = ({ handleLogout }) => {
       </ul>
 
       <ul style={ulStyle}>
-        <li>PDF API Test. Numbers correspond to quantity of rows in the db table.</li>
-        <li><a href={pdfApi100Path}>API: 100</a></li>
-        <li><a href={pdfApi400Path}>API: 400</a></li>
-        <li><a href={pdfApiAllPath}>API: All</a></li>
-      </ul>
-
-      <ul style={ulStyle}>
-        <li>PGenerate PDF Test. Numbers correspond to quantity of rows in the db table.</li>
+        <li>Old PDF Test. (Numbers correspond to quantity of rows in the db table).</li>
         <li><a href={pdfRender100Path}>PDF: 100</a></li>
         <li><a href={pdfRender400Path}>PDF: 400</a></li>
         <li><a href={pdfRenderAllPath}>PDF: All</a></li>
+      </ul>
+
+      <ul style={ulStyle}>
+        <li>New PDF And Query Test. html table vs div table.</li>
+        <li><a href={navHtmlTable}>HTML Only with Table</a></li>
+        <li><a href={navPdfTable}>PDF with Table</a></li>
+        <li>|||</li>
+        <li><a href={navDivTable}>HTML Only with Div table</a></li>
+        <li><a href={navPdfDiv}>PDF with Div table</a></li>
       </ul>
 
     </div>


### PR DESCRIPTION
- query includes duplicates of task's id based on tasksparts rows. Specific check added to handle so task labor is only calculated once.
- issues with table generation in pdf using xhtml2pdf (Reportlab lib under the hood) using pisa:
1. some css not working when pdf generated but works in the html: https://stackoverflow.com/questions/30957244/xhtml2pdf-pisa-css-broken-none-functional
2. rendering hangs: https://stackoverflow.com/questions/7594922/pisa-pdf-converter-is-very-slow-with-large-tables
3. working with bigger tables issue: https://groups.google.com/forum/#!topic/xhtml2pdf/vUoq1IRauvg


Possible solution using heroku addon (beta as of March 2019):
https://devcenter.heroku.com/articles/webtopdf