### PR TITLE
modified the on_delete in TasksParts so relationship is removed.

### DIFF
--- a/inventory/models.py
+++ b/inventory/models.py
@@ -145,8 +145,8 @@ class GlobalMarkup(models.Model):
 
 
 class TasksParts(models.Model):
-  task = models.ForeignKey(Tasks, on_delete=models.SET_NULL, blank=True, null=True)
-  part = models.ForeignKey(Parts, on_delete=models.SET_NULL, blank=True, null=True)
+  task = models.ForeignKey(Tasks, on_delete=models.CASCADE, blank=True, null=True)
+  part = models.ForeignKey(Parts, on_delete=models.CASCADE, blank=True, null=True)
   quantity = models.IntegerField()
 
   @property


### PR DESCRIPTION
- when a Task or Part is deleted, the relationship in TasksParts should be deleted.
- other models will continue to be SET_NULL so that the child objects are NOT deleted when the parent object is deleted.