### PR TITLE
reworked tag_types for all items. renamed fields in detail view.

### DIFF
--- a/web/src/components/Tasks/TaskFormFields.js
+++ b/web/src/components/Tasks/TaskFormFields.js
@@ -680,7 +680,7 @@ class TaskFormFields extends Component {
           />
 
           <Select
-            title={'Task Attribute'}
+            title={'Task Type'}
             placeholder={'Select a task attribute'}
             value={this.state.task_attribute}
             options={taskAttributeOptions}
@@ -704,21 +704,21 @@ class TaskFormFields extends Component {
 
           <Input 
             type={'text'}
-            title={'Estimated Contractor Hours'}
+            title={'Tech Task Hours'}
             value={this.state.estimated_contractor_hours}
             handleChange={this.handleEstContractorHours}
           />
 
           <Input 
             type={'text'}
-            title={'Estimated Contractor Minutes'}
+            title={'Tech Add On Minutes'}
             value={this.state.estimated_contractor_minutes}
             handleChange={this.handleEstContractorMinutes}
           />
 
           <Input
             type={'text'}
-            title={'Estimated Assistant Hours'}
+            title={'Assistant Task Hours'}
             placeholder={'0.00'}
             value={this.state.estimated_asst_hours}
             handleChange={this.handleEstAssistantHours}
@@ -726,7 +726,7 @@ class TaskFormFields extends Component {
           
           <Input 
             type={'text'}
-            title={'Estimated Assistant Minutes'}
+            title={'Assistant Add On Minutes'}
             placeholder={'0.00'}
             value={this.state.estimated_asst_minutes}
             handleChange={this.handleEstAssistantMinutes}

--- a/web/src/components/common/DetailsTable.js
+++ b/web/src/components/common/DetailsTable.js
@@ -7,11 +7,11 @@ const tableStyles = {
   // borderStyle: 'solid'
 };
 // shape of data is a single object
-const DetailsTable = ({ data, tagTypes, relatedChild, relatedParent, fetchType, numberOfLinks }) => {
-  // parts: array; tasks or categories: string. category uses jobs for tag types
-  const tagTypesAsString = (tagTypes.length) ? 
+const DetailsTable = ({ data, tagTypes=null, relatedChild, relatedParent, fetchType, numberOfLinks }) => {
+  // parts: array; non-parts: default to null. tagTypes have been merged with data
+  const tagTypesAsString = (tagTypes !== null && tagTypes.length) ? 
     tagTypes.map(({ tag_name }) => tag_name).join(', ').toString() 
-    : tagTypes.tag_name || tagTypes.job_name || '';
+    : null;
 
   const relatedParentRow = relatedParent ? 
     <tr><td>category</td><td>{relatedParent}</td></tr> 
@@ -25,6 +25,13 @@ const DetailsTable = ({ data, tagTypes, relatedChild, relatedParent, fetchType, 
       numberOfLinks={numberOfLinks}
     /> : '';
 
+  // non-part tagType renaming has been merged into data.
+  const displayTagtypes = tagTypes !== null ?
+    <tr>
+      <td>Tags</td>
+      <td>{tagTypesAsString}</td>
+    </tr>
+    : null;
 
   return (
     <div>
@@ -43,10 +50,7 @@ const DetailsTable = ({ data, tagTypes, relatedChild, relatedParent, fetchType, 
             </tr>
           )
         })}
-        <tr>
-          <td>tag_types</td>
-          <td>{tagTypesAsString}</td>
-        </tr>
+        {displayTagtypes}
         {relatedParentRow}
       </tbody>
     </table>

--- a/web/src/components/fieldNameAliases.js
+++ b/web/src/components/fieldNameAliases.js
@@ -84,8 +84,22 @@ const taskSearchResultsTableFields = {
   categories: 'Category',
 };
 
+// task's item detail, not search or related
 const taskDetailFormFields = {
-
+  id: 'ID',
+  task_id: 'Task ID',
+  task_name: 'Task Name',
+  task_desc: 'Description',
+  task_comments: 'Comment',
+  task_attribute: 'Task Type',
+  tag_types: 'Tags',
+  estimated_contractor_hours: 'Tech Task Hours',
+  estimated_contractor_minutes: 'Tech Add On Minutes',
+  estimated_asst_hours: 'Assistant Task Hours',
+  estimated_asst_minutes: 'Assistant Add On Minutes',
+  fixed_labor_rate: 'Fixed Rate',
+  use_fixed_labor_rate: 'Use Fixed Rate',
+  is_active: 'Task Active'
 };
 
 
@@ -110,7 +124,12 @@ const categorySearchResultsTableFields = {
 };
 
 const categoryDetailFormFields = {
-
+  id: 'ID',
+  category_id: 'Category ID',
+  category_name: 'Category Name',
+  category_desc: 'Description',
+  tag_types: 'Tags',
+  is_active: 'Category Active',
 };
 
 
@@ -127,7 +146,12 @@ const jobRelatedCategoriesTableFields = {
 };
 
 const jobDetailFormFields = {
-
+  id: 'ID',
+  job_id: 'Job ID',
+  job_name: 'Job Name',
+  job_desc: 'Description',
+  ordering_num: 'Ordering',
+  is_active: 'Job Active',
 };
 
 // doubling properties to handle pluralized keys
@@ -138,17 +162,17 @@ const staticDetailTableFields = {
     parent: partDetailRelatedTasksTableFields
   },
   task: {
-    form: '',
+    form: taskDetailFormFields,
     search: taskSearchResultsTableFields,
     child: taskDetailRelatedPartsTableFields,
   },
   category: {
-    form: '',
+    form: categoryDetailFormFields,
     child: categoryDetailRelatedTasksTableFields,
     search: categorySearchResultsTableFields,
   },
   job: {
-    form: '',
+    form: jobDetailFormFields,
     child: jobRelatedCategoriesTableFields,
   },
 };
@@ -188,8 +212,8 @@ const renameStaticTableFields = (resultsArr, targetType, viewType) => {
 
 /*
 dataObj: object. DetailView and DetailTable contains data in object.
-targetType: string. 'parts', 'tasks', 'category/categories'
-viewType: string. 'form, search, child/parent'
+targetType: string. 'part', 'task', 'category/categories'. Singularize name.
+viewType: string. 'form, search, child/parent, etc'
 */
 const renameStaticObjTableFields = (dataObj, targetType, viewType) => {
   const itemKeys = Object.keys(dataObj);


### PR DESCRIPTION
multiple conditions for tag_types:
part tag_types: array. Dealt with separately in PartsDetailWithState

task tag_types: required field, object.

category tag_types: does not exist. Uses the job_name as tag_type. Can be in 2 states:
1. tag_types is null (category is not related to a job. ie: newly created categories): convert value to "This category does not belong to a job."
2. tag_types.job_name (uses job_name)

job tag_types: redundant field. Will not exist in fetched data. Created a tag_types object as a placeholder for consistency.

-removed tagTypes prop from DetailsTable when not used.
-default tagTypes prop to null and handles null.
-parts will use tagTypes prop and will pass in an array.