### PR TITLE
added handling when a category tag type is null.

### DIFF
--- a/web/src/components/common/TableRow.js
+++ b/web/src/components/common/TableRow.js
@@ -6,6 +6,10 @@ import Input from './Input';
 
 
 const convertTagTypesToJoinedString = (arrObj) => {
+  // category tag types can be null
+  if (!arrObj) {
+    return '';
+  }
   const value = arrObj.length ? arrObj.map(({ tag_name }) => {
     return tag_name;
   }).join(', ').toString()


### PR DESCRIPTION
-newly created category will have null tag type. This is because it has not been assigned to a job yet.